### PR TITLE
Proof of concept for nested enum

### DIFF
--- a/conduit/data/datamodules/vision/nico.py
+++ b/conduit/data/datamodules/vision/nico.py
@@ -9,7 +9,7 @@ from ranzen import implements
 from conduit.data.datamodules.base import CdtDataModule
 from conduit.data.datamodules.vision.base import CdtVisionDataModule
 from conduit.data.datasets.utils import stratified_split
-from conduit.data.datasets.vision.nico import NICO, NicoSuperclass
+from conduit.data.datasets.vision.nico import NICO
 from conduit.data.structures import TrainValTestSplit
 
 __all__ = ["NICODataModule"]
@@ -21,7 +21,7 @@ class NICODataModule(CdtVisionDataModule):
 
     image_size: int = 224
     class_train_props: Optional[dict] = None
-    superclass: NicoSuperclass = NicoSuperclass.animals
+    superclass: NICO.Superclass = NICO.Superclass.animals
 
     @property  # type: ignore[misc]
     @implements(CdtVisionDataModule)

--- a/conduit/data/datasets/vision/nico.py
+++ b/conduit/data/datasets/vision/nico.py
@@ -14,20 +14,18 @@ from conduit.data.datasets.vision.base import CdtVisionDataset
 
 __all__ = [
     "NICO",
-    "NicoSuperclass",
 ]
-
-
-@enum_name_str
-class NicoSuperclass(Enum):
-    animals = auto()
-    vehicles = auto()
 
 
 class NICO(CdtVisionDataset):
     """Datset for Non-I.I.D. image classification introduced in
     'Towards Non-I.I.D. Image Classification: A Dataset and Baselines'
     """
+
+    @enum_name_str
+    class Superclass(Enum):
+        animals = auto()
+        vehicles = auto()
 
     _FILE_INFO: ClassVar[GdriveFileInfo] = GdriveFileInfo(
         name="NICO.zip",
@@ -42,11 +40,11 @@ class NICO(CdtVisionDataset):
         *,
         download: bool = True,
         transform: Optional[ImageTform] = None,
-        superclass: Optional[Union[NicoSuperclass, str]] = NicoSuperclass.animals,
+        superclass: Optional[Union[Superclass, str]] = Superclass.animals,
     ) -> None:
 
         self.superclass = (
-            str_to_enum(str_=superclass, enum=NicoSuperclass)
+            str_to_enum(str_=superclass, enum=NICO.Superclass)
             if isinstance(superclass, str)
             else superclass
         )
@@ -90,7 +88,7 @@ class NICO(CdtVisionDataset):
         super().__init__(x=x, y=y, s=s, transform=transform, image_dir=self._base_dir)
 
     def _check_unzipped(self) -> bool:
-        return all((self._base_dir / sc.name).exists() for sc in NicoSuperclass)
+        return all((self._base_dir / sc.name).exists() for sc in NICO.Superclass)
 
     def _extract_metadata(self) -> None:
         """Extract concept/context/superclass information from the image filepaths and it save to csv."""

--- a/conduit/hydra/conduit/data/datamodules/conf.py
+++ b/conduit/hydra/conduit/data/datamodules/conf.py
@@ -9,7 +9,7 @@ from builtins import dict
 from conduit.data.datasets.vision.camelyon17 import Camelyon17Attr
 from conduit.data.datasets.vision.camelyon17 import Camelyon17SplitScheme
 from conduit.data.datasets.vision.celeba import CelebAttr
-from conduit.data.datasets.vision.nico import NicoSuperclass
+from conduit.data.datasets.vision.nico import NICO
 from omegaconf import MISSING
 from ranzen.torch.data import TrainingMode
 from typing import Any
@@ -90,7 +90,7 @@ class NICODataModuleConf:
     test_transforms: Any = None  # Union[Compose, BasicTransform, Callable[[Image], Any], NoneType]
     image_size: int = 224
     class_train_props: Optional[dict] = None
-    superclass: NicoSuperclass = NicoSuperclass.animals
+    superclass: NICO.Superclass = NICO.Superclass.animals
 
 
 @dataclass

--- a/conduit/hydra/conduit/data/datasets/conf.py
+++ b/conduit/hydra/conduit/data/datasets/conf.py
@@ -10,7 +10,7 @@ from conduit.data.datasets.vision.camelyon17 import Camelyon17Attr
 from conduit.data.datasets.vision.camelyon17 import Camelyon17SplitScheme
 from conduit.data.datasets.vision.celeba import CelebAttr
 from conduit.data.datasets.vision.isic import IsicAttr
-from conduit.data.datasets.vision.nico import NicoSuperclass
+from conduit.data.datasets.vision.nico import NICO
 from conduit.data.datasets.vision.ssrp import SSRPSplit
 from omegaconf import MISSING
 from typing import Any
@@ -66,7 +66,7 @@ class NICOConf:
     root: Any = MISSING  # Union[str, Path]
     download: bool = True
     transform: Any = None  # Union[Compose, BasicTransform, Callable[[Image], Any], NoneType]
-    superclass: Any = NicoSuperclass.animals  # Union[NicoSuperclass, str, NoneType]
+    superclass: Any = NICO.Superclass.animals  # Union[NICO.Superclass, str, NoneType]
 
 
 @dataclass


### PR DESCRIPTION
Neoconfigen ran without error, but it produced an incorrect import. I had to fix that manually.

```
Python 3.9.7 (default, Sep 10 2021, 14:59:43)
[GCC 11.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from conduit.hydra.conduit.data.datamodules.conf import NICODataModuleConf
>>> c = NICODataModuleConf()
>>> c.superclass
Superclass.animals
>>> type(c.superclass)
<enum 'Superclass'>
```