### PR TITLE
make ecoacoustics hyda instantiable

### DIFF
--- a/conduit/data/datamodules/audio/base.py
+++ b/conduit/data/datamodules/audio/base.py
@@ -1,6 +1,5 @@
 """Base class for audio datasets."""
-from pathlib import Path
-from typing import Optional, TypeVar, Union
+from typing import Optional, TypeVar
 
 import attr
 from ranzen.decorators import implements
@@ -21,7 +20,7 @@ D = TypeVar("D", bound=SizedDataset)
 @attr.define(kw_only=True)
 class CdtAudioDataModule(CdtDataModule[D, I]):
 
-    root: Union[str, Path] = attr.field(kw_only=False)
+    root: str = attr.field(kw_only=False)
     _train_transforms: Optional[AudioTform] = None
     _test_transforms: Optional[AudioTform] = None
 

--- a/conduit/data/datamodules/audio/ecoacoustics.py
+++ b/conduit/data/datamodules/audio/ecoacoustics.py
@@ -1,5 +1,5 @@
 """Ecoacoustics data-module."""
-from typing import Any
+from typing import Any, List
 
 import attr
 from pytorch_lightning import LightningDataModule
@@ -19,7 +19,7 @@ class EcoacousticsDataModule(CdtAudioDataModule[Ecoacoustics, TernarySample]):
     """Data-module for the Ecoacoustics dataset."""
 
     segment_len: float = 15
-    target_attrs: SoundscapeAttr
+    target_attrs: List[SoundscapeAttr]
 
     @implements(LightningDataModule)
     def prepare_data(self, *args: Any, **kwargs: Any) -> None:

--- a/conduit/data/datamodules/audio/ecoacoustics.py
+++ b/conduit/data/datamodules/audio/ecoacoustics.py
@@ -1,5 +1,5 @@
 """Ecoacoustics data-module."""
-from typing import Any, List, Union
+from typing import Any
 
 import attr
 from pytorch_lightning import LightningDataModule
@@ -19,7 +19,7 @@ class EcoacousticsDataModule(CdtAudioDataModule[Ecoacoustics, TernarySample]):
     """Data-module for the Ecoacoustics dataset."""
 
     segment_len: float = 15
-    target_attrs: Union[SoundscapeAttr, List[SoundscapeAttr]]
+    target_attrs: SoundscapeAttr
 
     @implements(LightningDataModule)
     def prepare_data(self, *args: Any, **kwargs: Any) -> None:

--- a/conduit/data/datasets/audio/ecoacoustics.py
+++ b/conduit/data/datasets/audio/ecoacoustics.py
@@ -22,7 +22,7 @@ import torch
 from torch import Tensor
 import torchaudio  # type: ignore
 from tqdm import tqdm  # type: ignore
-from typing_extensions import TypeAlias
+from typing_extensions import Final, TypeAlias
 
 from conduit.data.datasets.audio.base import CdtAudioDataset
 from conduit.data.datasets.utils import AudioTform, UrlFileInfo, download_from_url
@@ -75,12 +75,12 @@ class Ecoacoustics(CdtAudioDataset[SampleType, Tensor, Tensor]):
     ]
 
     _num_frames_in_segment: Optional[int]
-    _MAX_AUDIO_LEN = 60
+    _MAX_AUDIO_LEN: Final[int] = 60
 
     @parsable
     def __init__(
         self,
-        root: Union[str, Path],
+        root: str,
         *,
         transform: Optional[AudioTform] = None,
         download: bool = True,
@@ -130,8 +130,7 @@ class Ecoacoustics(CdtAudioDataset[SampleType, Tensor, Tensor]):
     def segment_len(self, value: float) -> None:
         if value <= 0:
             raise ValueError("Segment length must be positive.")
-        if value > self._MAX_AUDIO_LEN:
-            value = self._MAX_AUDIO_LEN
+        value = min(value, self._MAX_AUDIO_LEN)
         self._segment_len = value
         self._num_frames_in_segment = int(self.segment_len * self.sample_rate)
 

--- a/tests/data_test.py
+++ b/tests/data_test.py
@@ -101,16 +101,16 @@ def test_vision_datasets(
 def test_audio_dataset(root: Path, segment_len: float) -> None:
 
     ds = Ecoacoustics(
-        root=root,
+        root=str(root),
         download=True,
-        target_attrs=[SoundscapeAttr.habitat, SoundscapeAttr.site],
+        target_attrs=SoundscapeAttr.site,
         transform=None,
         segment_len=segment_len,
     )
 
     assert len(ds) == len(ds.x) == len(ds.metadata)
     assert ds.y is not None
-    assert ds.y.shape == (len(ds), 2)
+    assert ds.y.shape == (len(ds),)
     assert ds.y.dtype == torch.long
     num_frames = (
         ds._MAX_AUDIO_LEN * ds.sample_rate if segment_len is None else segment_len * ds.sample_rate
@@ -126,7 +126,7 @@ def test_audio_dataset(root: Path, segment_len: float) -> None:
 def test_ecoacoustics_labels(root: Path):
     target_attr = SoundscapeAttr.habitat
     ds = Ecoacoustics(
-        root=root,
+        root=str(root),
         download=True,
         target_attrs=target_attr,
         segment_len=1,
@@ -148,7 +148,7 @@ def test_ecoacoustics_labels(root: Path):
 @pytest.mark.slow
 def test_ecoacoustics_dm(root: Path):
     dm = EcoacousticsDataModule(
-        root=root,
+        root=str(root),
         segment_len=30.0,
         target_attrs=SoundscapeAttr.habitat,
         train_transforms=AT.Spectrogram(),

--- a/tests/data_test.py
+++ b/tests/data_test.py
@@ -103,14 +103,14 @@ def test_audio_dataset(root: Path, segment_len: float) -> None:
     ds = Ecoacoustics(
         root=str(root),
         download=True,
-        target_attrs=SoundscapeAttr.site,
+        target_attrs=[SoundscapeAttr.habitat, SoundscapeAttr.site],
         transform=None,
         segment_len=segment_len,
     )
 
     assert len(ds) == len(ds.x) == len(ds.metadata)
     assert ds.y is not None
-    assert ds.y.shape == (len(ds),)
+    assert ds.y.shape == (len(ds), 2)
     assert ds.y.dtype == torch.long
     num_frames = (
         ds._MAX_AUDIO_LEN * ds.sample_rate if segment_len is None else segment_len * ds.sample_rate
@@ -124,7 +124,7 @@ def test_audio_dataset(root: Path, segment_len: float) -> None:
 
 @pytest.mark.slow
 def test_ecoacoustics_labels(root: Path):
-    target_attr = SoundscapeAttr.habitat
+    target_attr = [SoundscapeAttr.habitat]
     ds = Ecoacoustics(
         root=str(root),
         download=True,
@@ -142,7 +142,7 @@ def test_ecoacoustics_labels(root: Path):
     for sample, label in zip(audio_samples_to_check, habitat_target_attributes):
         matched_row = ds.metadata.loc[ds.metadata["fileName"] == sample]
         if isinstance(label, str):
-            assert matched_row.iloc[0][str(target_attr)] == label
+            assert matched_row.iloc[0][str(target_attr[0])] == label
 
 
 @pytest.mark.slow
@@ -150,7 +150,7 @@ def test_ecoacoustics_dm(root: Path):
     dm = EcoacousticsDataModule(
         root=str(root),
         segment_len=30.0,
-        target_attrs=SoundscapeAttr.habitat,
+        target_attrs=[SoundscapeAttr.habitat],
         train_transforms=AT.Spectrogram(),
     )
     dm.prepare_data()


### PR DESCRIPTION
removed union types. Went for `List[target_label]` as that is the more general of the two options and I think multi-lable functionality was required, though I don't really remember