### PR TITLE
bug/fix audio sampling

### DIFF
--- a/conduit/data/datamodules/audio/ecoacoustics.py
+++ b/conduit/data/datamodules/audio/ecoacoustics.py
@@ -27,7 +27,7 @@ class EcoacousticsDataModule(CdtAudioDataModule[Ecoacoustics, TernarySample]):
 
     @staticmethod
     def _batch_converter(batch: BinarySample) -> BinarySample:
-        return BinarySample(x=batch.x, y=batch.y.expand(batch.x.shape[0]))
+        return BinarySample(x=batch.x, y=batch.y)
 
     def make_dataloader(
         self,

--- a/conduit/data/datasets/audio/ecoacoustics.py
+++ b/conduit/data/datasets/audio/ecoacoustics.py
@@ -266,8 +266,10 @@ class Ecoacoustics(CdtAudioDataset[SampleType, Tensor, Tensor]):
             self.num_frames_in_segment / self.sample_rate * metadata.sample_rate
         )
 
-        # compute offset
-        high = max(1, metadata.num_frames - self.num_frames_in_segment)
+        # when the number of frames in the data is greater than the
+        # specified number of frames, apply i.i.d. sampling, slice off
+        # a randomised portion of the sample using an offset
+        high = max(1, metadata.num_frames - num_frames_segment)
         frame_offset = torch.randint(low=0, high=high, size=(1,))
 
         # load segment

--- a/tests/data_test.py
+++ b/tests/data_test.py
@@ -6,7 +6,7 @@ import numpy as np
 import pytest
 import torch
 from torch import Tensor
-import torchaudio.transforms as AT
+import torchaudio.transforms as AT # type: ignore
 from torchvision import transforms as T
 from typing_extensions import Type
 
@@ -32,6 +32,7 @@ from conduit.data import (
 from conduit.data.datamodules import EcoacousticsDataModule
 from conduit.data.datamodules.tabular.dummy import DummyTabularDataModule
 from conduit.data.datamodules.vision.dummy import DummyVisionDataModule
+from conduit.transforms.audio import Framing
 from conduit.data.datasets import ISIC, ColoredMNIST, Ecoacoustics
 from conduit.data.datasets.utils import get_group_ids, stratified_split
 from conduit.data.datasets.vision.cmnist import MNISTColorizer
@@ -123,7 +124,7 @@ def test_audio_dataset(root: Path, segment_len: float) -> None:
 
 
 @pytest.mark.slow
-def test_ecoacoustics_labels(root: Path):
+def test_ecoacoustics_metadata_labels(root: Path):
     target_attr = [SoundscapeAttr.habitat]
     ds = Ecoacoustics(
         root=str(root),
@@ -143,7 +144,6 @@ def test_ecoacoustics_labels(root: Path):
         matched_row = ds.metadata.loc[ds.metadata["fileName"] == sample]
         if isinstance(label, str):
             assert matched_row.iloc[0][str(target_attr[0])] == label
-
 
 @pytest.mark.slow
 def test_ecoacoustics_dm(root: Path):
@@ -165,6 +165,35 @@ def test_ecoacoustics_dm(root: Path):
     assert test_sample.x.size()[2] == dm.dims[1]
     assert test_sample.x.size()[3] == dm.dims[2]
 
+@pytest.mark.slow
+def test_ecoacoustics_dm_batch_multi_label(root: Path) -> None:
+    target_attrs = [SoundscapeAttr.habitat, SoundscapeAttr.site]
+    data_module = EcoacousticsDataModule(root=str(root),
+                                         segment_len=30.0,
+                                         target_attrs=target_attrs,
+                                         train_transforms=AT.Spectrogram())
+    data_module.prepare_data()
+    data_module.setup()
+
+    train_dl = data_module.train_dataloader()
+    sample = next(iter(train_dl))
+
+    assert sample.y.size(1) == len(target_attrs)
+
+@pytest.mark.slow
+def test_ecoacoustics_dm_batch_multi_label_framed(root: Path) -> None:
+    target_attrs = [SoundscapeAttr.habitat, SoundscapeAttr.site]
+    data_module = EcoacousticsDataModule(root=str(root),
+                                         segment_len=30.0,
+                                         target_attrs=target_attrs,
+                                         train_transforms=torch.nn.Sequential(AT.Spectrogram(), Framing()))
+    data_module.prepare_data()
+    data_module.setup()
+
+    train_dl = data_module.train_dataloader()
+    sample = next(iter(train_dl))
+
+    assert sample.y.size(1) == len(target_attrs)
 
 def test_add_field() -> None:
     x = torch.rand(3, 2)


### PR DESCRIPTION
fixes a bug where the wrong number of frames is used to calculate the offset for random sampling within the bounds of the sample 

behaviour is now, where the number of frames in the data is greater than the specified number of frames, apply i.i.d. sampling, slice off a randomised portion of the sample using the offset. If number of frames is less than or equal to the specified number, the offset is `rand(0, 1) = 0` (therefore no offset). When greater, the offset is `rand(0, n)` where `n` is the difference between the total number of frames and the specified number of frames (i.e. the maximum we can take to accommodate the specified number of frames).