### PR TITLE
Fix: compute offset correctly

### DIFF
--- a/conduit/data/datasets/audio/ecoacoustics.py
+++ b/conduit/data/datasets/audio/ecoacoustics.py
@@ -266,8 +266,10 @@ class Ecoacoustics(CdtAudioDataset[SampleType, Tensor, Tensor]):
             self.num_frames_in_segment / self.sample_rate * metadata.sample_rate
         )
 
-        # compute offset
-        high = max(1, metadata.num_frames - self.num_frames_in_segment)
+        # when the number of frames in the data is greater than the
+        # specified number of frames, apply i.i.d. sampling, slice off
+        # a randomised portion of the sample using an offset
+        high = max(1, metadata.num_frames - num_frames_segment)
         frame_offset = torch.randint(low=0, high=high, size=(1,))
 
         # load segment

--- a/conduit/data/datasets/audio/ecoacoustics.py
+++ b/conduit/data/datasets/audio/ecoacoustics.py
@@ -266,9 +266,7 @@ class Ecoacoustics(CdtAudioDataset[SampleType, Tensor, Tensor]):
             self.num_frames_in_segment / self.sample_rate * metadata.sample_rate
         )
 
-        # when the number of frames in the data is greater than the
-        # specified number of frames, apply i.i.d. sampling, slice off
-        # a randomised portion of the sample using an offset
+        # get random sub-sample
         high = max(1, metadata.num_frames - num_frames_segment)
         frame_offset = torch.randint(low=0, high=high, size=(1,))
 


### PR DESCRIPTION
fixes a bug where the wrong number of frames is used to calculate the offset for random sampling within the bounds of the sample

behaviour is now, where the number of frames in the data is greater than the specified number of frames, apply i.i.d. sampling, slice off a randomised portion of the sample using the offset. If number of frames is less than or equal to the specified number, the offset is rand(0, 1) = 0 (therefore no offset). When greater, the offset is rand(0, n) where n is the difference between the total number of frames and the specified number of frames (i.e. the maximum we can take to accommodate the specified number of frames).