### PR TITLE
bug/fix label mapping

### DIFF
--- a/conduit/data/datasets/audio/ecoacoustics.py
+++ b/conduit/data/datasets/audio/ecoacoustics.py
@@ -39,8 +39,8 @@ class SoundscapeAttr(Enum):
     habitat = auto()
     site = auto()
     time = auto()
-    nn = auto()
-    n0 = auto()
+    NN = auto()
+    N0 = auto()
 
 
 SampleType: TypeAlias = TernarySample

--- a/conduit/data/datasets/audio/ecoacoustics.py
+++ b/conduit/data/datasets/audio/ecoacoustics.py
@@ -97,9 +97,9 @@ class Ecoacoustics(CdtAudioDataset[SampleType, Tensor, Tensor]):
         self._metadata_path = self.base_dir / self._METADATA_FILENAME
         self.ec_labels_path = self.labels_dir / self._EC_LABELS_FILENAME
         self.uk_labels_path = self.labels_dir / self._UK_LABELS_FILENAME
-
+        # map provided attributes (as string or enum) to permitted attributes (as strings)
         self.target_attrs = [
-            str(str_to_enum(str_=elem, enum=SoundscapeAttr)) for elem in target_attrs
+            str_to_enum(str_=elem, enum=SoundscapeAttr).name for elem in target_attrs
         ]
 
         if self.download:


### PR DESCRIPTION
some attributes in the `metadata.csv` file are capitalised or partially so (e.g. `NN, N0, H.s`). These were not so in the `SoundscapeAttr` enum definition, and thus `enum.name` did not match the field in the metadata file, causing an error when attempting to load these attributes. This capitalises the enum names so they match the fixed ones in the metadata file. 

Second issue, when parsing provided attributes to the dataset (either as string or enum), the output was being downcased, causing the same error to occur. Fixed by removing `str(...)` which was downcasing the field name.

```
>>> x = [str_to_enum(str_=elem.name, enum=SoundscapeAttr) for elem in target_attrs]
>>> x[3]
SoundscapeAttr.NN
>>> x[3].name
'NN'
>>> str(x[3])
'nn'
```