### PR TITLE
add md attributes and switch to using a ternary sample in ecoacoustics

### DIFF
--- a/conduit/data/datamodules/audio/ecoacoustics.py
+++ b/conduit/data/datamodules/audio/ecoacoustics.py
@@ -7,9 +7,13 @@ from ranzen import implements
 from torch.utils.data import Sampler
 
 from conduit.data.datamodules.base import CdtDataModule
-from conduit.data.datasets.audio.ecoacoustics import Ecoacoustics, SoundscapeAttr
+from conduit.data.datasets.audio.ecoacoustics import (
+    Ecoacoustics,
+    MDAttr,
+    SoundscapeAttr,
+)
 from conduit.data.datasets.utils import AudioTform, CdtDataLoader
-from conduit.data.structures import BinarySample, TernarySample, TrainValTestSplit
+from conduit.data.structures import TernarySample, TrainValTestSplit
 from conduit.transforms.audio import Compose, Framing, LogMelSpectrogram
 
 from .base import CdtAudioDataModule
@@ -24,10 +28,7 @@ class EcoacousticsDataModule(CdtAudioDataModule[Ecoacoustics, TernarySample]):
     segment_len: float = 15
     sample_rate: int = 48_000
     target_attrs: List[SoundscapeAttr]
-
-    @staticmethod
-    def _batch_converter(batch: BinarySample) -> BinarySample:
-        return BinarySample(x=batch.x, y=batch.y)
+    md_attrs: List[MDAttr] = list(MDAttr)
 
     def make_dataloader(
         self,
@@ -37,7 +38,7 @@ class EcoacousticsDataModule(CdtAudioDataModule[Ecoacoustics, TernarySample]):
         shuffle: bool = False,
         drop_last: bool = False,
         batch_sampler: Optional[Sampler[Sequence[int]]] = None,
-    ) -> CdtDataLoader[BinarySample]:
+    ) -> CdtDataLoader[TernarySample]:
         """Make DataLoader."""
         return CdtDataLoader(
             ds,
@@ -48,7 +49,6 @@ class EcoacousticsDataModule(CdtAudioDataModule[Ecoacoustics, TernarySample]):
             drop_last=drop_last,
             persistent_workers=self.persist_workers,
             batch_sampler=batch_sampler,
-            converter=self._batch_converter,
         )
 
     @implements(LightningDataModule)
@@ -58,6 +58,7 @@ class EcoacousticsDataModule(CdtAudioDataModule[Ecoacoustics, TernarySample]):
             download=True,
             segment_len=self.segment_len,
             target_attrs=self.target_attrs,
+            md_attrs=self.md_attrs,
         )
 
     @property
@@ -81,6 +82,7 @@ class EcoacousticsDataModule(CdtAudioDataModule[Ecoacoustics, TernarySample]):
             transform=None,  # Transform is applied in `CdtAudioDataModule._setup`
             segment_len=self.segment_len,
             target_attrs=self.target_attrs,
+            md_attrs=self.md_attrs,
             sample_rate=self.sample_rate,
             download=False,
         )

--- a/conduit/data/datasets/audio/ecoacoustics.py
+++ b/conduit/data/datasets/audio/ecoacoustics.py
@@ -9,7 +9,7 @@ from enum import Enum, auto
 import math
 from pathlib import Path
 import shutil
-from typing import ClassVar, List, Optional, Tuple, Union, cast
+from typing import ClassVar, List, Optional, Tuple, Union, cast, Dict
 import zipfile
 
 import numpy as np
@@ -121,10 +121,6 @@ class Ecoacoustics(CdtAudioDataset[SampleType, Tensor, Tensor]):
 
         self.metadata = pd.read_csv(self.base_dir / self._METADATA_FILENAME)
         # map numerical indices to target attributes
-        self.md_decoder = self.metadata[self.md_attrs].to_dict()
-        encoded_targets = [SoundscapeAttr.habitat.name, SoundscapeAttr.site.name]
-        self.target_attr_decoder = self.metadata[encoded_targets].to_dict()
-
         x = self.metadata["filePath"].to_numpy()
         y = torch.as_tensor(
             self._label_encode(self.metadata[self.target_attrs], inplace=True).to_numpy()
@@ -166,6 +162,10 @@ class Ecoacoustics(CdtAudioDataset[SampleType, Tensor, Tensor]):
                 )
             if zipfile.is_zipfile(dir_):
                 raise RuntimeError(f"{dir_} file not unzipped.")
+
+    def label_decoder(self) -> Dict[SoundscapeAttr, Dict[str, int]]:
+        encoded_targets = [SoundscapeAttr.habitat.name, SoundscapeAttr.site.name] + self.md_attrs
+        return self.metadata[encoded_targets].to_dict()
 
     @staticmethod
     def _label_encode(

--- a/conduit/data/datasets/audio/ecoacoustics.py
+++ b/conduit/data/datasets/audio/ecoacoustics.py
@@ -9,7 +9,7 @@ from enum import Enum, auto
 import math
 from pathlib import Path
 import shutil
-from typing import ClassVar, List, Optional, Tuple, Union, cast, Dict
+from typing import ClassVar, List, Optional, Tuple, Union, cast, Dict, Any
 import zipfile
 
 import numpy as np
@@ -163,7 +163,7 @@ class Ecoacoustics(CdtAudioDataset[SampleType, Tensor, Tensor]):
             if zipfile.is_zipfile(dir_):
                 raise RuntimeError(f"{dir_} file not unzipped.")
 
-    def label_decoder(self) -> Dict[SoundscapeAttr, Dict[str, int]]:
+    def label_decoder(self) -> Dict[str, Any]:
         encoded_targets = [SoundscapeAttr.habitat.name, SoundscapeAttr.site.name] + self.md_attrs
         return self.metadata[encoded_targets].to_dict()
 

--- a/conduit/data/datasets/audio/ecoacoustics.py
+++ b/conduit/data/datasets/audio/ecoacoustics.py
@@ -122,6 +122,8 @@ class Ecoacoustics(CdtAudioDataset[SampleType, Tensor, Tensor]):
         self.metadata = pd.read_csv(self.base_dir / self._METADATA_FILENAME)
         # map numerical indices to target attributes
         self.md_decoder = self.metadata[self.md_attrs].to_dict()
+        encoded_targets = [SoundscapeAttr.habitat.name, SoundscapeAttr.site.name]
+        self.target_attr_decoder = self.metadata[encoded_targets].to_dict()
 
         x = self.metadata["filePath"].to_numpy()
         y = torch.as_tensor(

--- a/conduit/data/datasets/audio/ecoacoustics.py
+++ b/conduit/data/datasets/audio/ecoacoustics.py
@@ -164,8 +164,7 @@ class Ecoacoustics(CdtAudioDataset[SampleType, Tensor, Tensor]):
                 raise RuntimeError(f"{dir_} file not unzipped.")
 
     def label_decoder(self) -> Dict[str, Any]:
-        encoded_targets = [SoundscapeAttr.habitat.name, SoundscapeAttr.site.name] + self.md_attrs
-        return self.metadata[encoded_targets].to_dict()
+        return self.metadata[self.target_attrs + self.md_attrs].to_dict()
 
     @staticmethod
     def _label_encode(

--- a/conduit/data/datasets/audio/ecoacoustics.py
+++ b/conduit/data/datasets/audio/ecoacoustics.py
@@ -9,7 +9,7 @@ from enum import Enum, auto
 import math
 from pathlib import Path
 import shutil
-from typing import ClassVar, List, Optional, Tuple, Union, cast, Dict, Any
+from typing import Any, ClassVar, Dict, List, Optional, Tuple, Union, cast
 import zipfile
 
 import numpy as np

--- a/conduit/data/datasets/audio/ecoacoustics.py
+++ b/conduit/data/datasets/audio/ecoacoustics.py
@@ -42,7 +42,7 @@ class SoundscapeAttr(Enum):
     time = auto()
     NN = auto()
     N0 = auto()
-    A_Den = auto()
+    A_Den = "A.Den"
 
 
 @enum_name_str

--- a/conduit/data/datasets/audio/ecoacoustics.py
+++ b/conduit/data/datasets/audio/ecoacoustics.py
@@ -109,9 +109,7 @@ class Ecoacoustics(CdtAudioDataset[SampleType, Tensor, Tensor]):
         self.target_attrs = [
             str_to_enum(str_=elem, enum=SoundscapeAttr).name for elem in target_attrs
         ]
-        self.md_attrs = [
-            str_to_enum(str_=elem, enum=MDAttr).name for elem in md_attrs
-        ]
+        self.md_attrs = [str_to_enum(str_=elem, enum=MDAttr).name for elem in md_attrs]
 
         if self.download:
             self._download_files()

--- a/conduit/data/datasets/audio/ecoacoustics.py
+++ b/conduit/data/datasets/audio/ecoacoustics.py
@@ -121,7 +121,7 @@ class Ecoacoustics(CdtAudioDataset[SampleType, Tensor, Tensor]):
 
         self.metadata = pd.read_csv(self.base_dir / self._METADATA_FILENAME)
         # map numerical indices to target attributes
-        self.concept_label_decoder = self.metadata[self.md_attrs].to_dict()
+        self.md_decoder = self.metadata[self.md_attrs].to_dict()
 
         x = self.metadata["filePath"].to_numpy()
         y = torch.as_tensor(

--- a/tests/data_test.py
+++ b/tests/data_test.py
@@ -160,7 +160,10 @@ def test_ecoacoustics_dm(root: Path):
     train_dl = dm.train_dataloader()
     test_sample = next(iter(train_dl))
 
-    # Test size().
+    # Test is a ternary sample
+    assert type(test_sample) == TernarySample
+
+    # Test size()
     assert test_sample.x.size()[1] == dm.dims[0]
     assert test_sample.x.size()[2] == dm.dims[1]
     assert test_sample.x.size()[3] == dm.dims[2]
@@ -185,6 +188,7 @@ def test_ecoacoustics_dm_batch_multi_label(root: Path, train_batch_size: int) ->
 
     assert sample.y.size(1) == len(target_attrs)
     assert sample.x.size(0) == sample.y.size(0) == train_batch_size
+    assert sample.s.size(0) == sample.y.size(0) == train_batch_size
 
 
 def test_add_field() -> None:


### PR DESCRIPTION
- removes the use of the batch converter
- switches ecoacoustic dataset to using `TernarySample`
- adds additional attributes enum `MDAttr` which at the moment just contains the `fileName` field from the metadata
- encodes filenames as integers in a tensor
- creates a dictionary decoder to index the filename string
- adds `A_Den` field for fetching `A.Den` target from the metadata (will this work?)