### PR TITLE
Remove final annotation from CdtDataset.__getitem__.

### DIFF
--- a/conduit/data/datasets/base.py
+++ b/conduit/data/datasets/base.py
@@ -297,7 +297,6 @@ class CdtDataset(SizedDataset, Generic[I, X, Y, S]):
             return superset
 
     @override
-    @final
     def __getitem__(self: Self, index: IndexType) -> I:
         x = self._sample_x(index, coerce_to_tensor=False)
         y = self._sample_y(index)


### PR DESCRIPTION
It turns out that there are instances where the safest and most expedient route is to override the `__getitem__` method, perhaps most notably (at least based on personal experience) wrapper classes which 'augment' an item from a base `CdtDataset`.