### PR TITLE
Make compatible with ranzen 2.1

### DIFF
--- a/conduit/data/datasets/utils.py
+++ b/conduit/data/datasets/utils.py
@@ -600,7 +600,7 @@ def random_split(
 
     :returns: Random subsets of the data (or their associated indices) of the requested proportions.
     """
-    split_indices = prop_random_split(dataset=dataset, props=props, as_indices=True, seed=seed)
+    split_indices = prop_random_split(dataset, props=props, as_indices=True, seed=seed)
     if as_indices:
         return split_indices
     splits = [make_subset(dataset, indices=indices, deep=deep) for indices in split_indices]


### PR DESCRIPTION
The first argument of `prop_random_split` was renamed from `dataset` to `dataset_or_indices`. To stay compatible with all ranzen versions, we'll just use a positional argument.