### PR TITLE
Make hard_predictions() work with batch_dim=1

### DIFF
--- a/conduit/metrics.py
+++ b/conduit/metrics.py
@@ -54,7 +54,7 @@ __all__ = [
 
 @torch.no_grad()
 def hard_prediction(logits: Tensor) -> Tensor:
-    logits = torch.atleast_1d(logits.squeeze())
+    logits = logits.squeeze(1) if logits.ndim == 2 else torch.atleast_1d(logits)
     return (logits > 0).long() if logits.ndim == 1 else logits.argmax(dim=1)
 
 


### PR DESCRIPTION
For a multi-class problem with batch dimension 1, the logits were interpreted as a batch of binary predictions.