### PR TITLE
Don't use settable properties in protocols

### DIFF
--- a/conduit/data/datasets/utils.py
+++ b/conduit/data/datasets/utils.py
@@ -696,7 +696,7 @@ def stratified_split(
                     f"No samples belonging to superclass 'y={superclass}' exist in the dataset of "
                     f"type {dataset.__class__.__name__}."
                 )
-            if isinstance(value, float):
+            if isinstance(value, (float, int)):
                 if not 0 <= value <= 1:
                     raise ValueError(
                         "All splitting proportions speicfied in 'train_props' must be in the "

--- a/conduit/data/structures.py
+++ b/conduit/data/structures.py
@@ -22,7 +22,7 @@ from typing import (
 from typing_extensions import Self, TypeAlias, override
 
 from PIL import Image
-import attr
+from attrs import define
 import numpy as np
 import numpy.typing as npt
 from ranzen.misc import gcopy, reduce_add
@@ -537,7 +537,7 @@ def shallow_asdict(dataclass: object) -> Dict[str, Any]:
     return {field.name: getattr(dataclass, field.name) for field in fields(dataclass)}
 
 
-@attr.define
+@define
 class ImageSize(Sequence):
     c: int
     h: int
@@ -545,7 +545,7 @@ class ImageSize(Sequence):
 
     def __mul__(self, other: Union[Self, float]) -> Self:
         copy = gcopy(self, deep=False)
-        if isinstance(other, float):
+        if isinstance(other, (float, int)):
             copy.c = round(copy.c * other)
             copy.h = round(copy.h * other)
             copy.w = round(copy.w * other)
@@ -577,7 +577,7 @@ class ImageSize(Sequence):
         return sum(iter(self))
 
 
-@attr.define(kw_only=True)
+@define(kw_only=True)
 class MeanStd:
     mean: Union[Tuple[float, ...], List[float]]
     std: Union[Tuple[float, ...], List[float]]
@@ -661,7 +661,7 @@ class DatasetWrapper(SizedDataset[R_co], Protocol):
         return None
 
 
-@attr.define(kw_only=True)
+@define(kw_only=True)
 class TrainTestSplit(Generic[D]):
     train: D
     test: D
@@ -670,7 +670,7 @@ class TrainTestSplit(Generic[D]):
         yield from (self.train, self.test)
 
 
-@attr.define(kw_only=True)
+@define(kw_only=True)
 class TrainValTestSplit(TrainTestSplit[D]):
     val: D
 

--- a/conduit/types.py
+++ b/conduit/types.py
@@ -28,15 +28,9 @@ METRIC_COLLECTION = Union[_METRIC, Mapping[str, _METRIC]]
 
 
 class Loss(Protocol):
+    reduction: Union[ReductionType, str]
+
     def __call__(self, input: Tensor, target: Tensor, **kwargs: Any) -> Tensor:
-        ...
-
-    @property
-    def reduction(self) -> Union[ReductionType, str]:
-        ...
-
-    @reduction.setter
-    def reduction(self, value: Union[ReductionType, str]) -> None:
         ...
 
 

--- a/tests/metrics_test.py
+++ b/tests/metrics_test.py
@@ -19,9 +19,9 @@ def generator() -> torch.Generator:
 
 
 def assert_close(a: Tensor | np.ndarray | float, b: Tensor | np.ndarray | float, /) -> None:
-    if isinstance(a, (np.ndarray, float)):
+    if isinstance(a, (np.ndarray, float, int)):
         a = torch.as_tensor(a, dtype=torch.float32)
-    if isinstance(b, (np.ndarray, float)):
+    if isinstance(b, (np.ndarray, float, int)):
         b = torch.as_tensor(b, dtype=torch.float32)
     a = torch.nan_to_num(a, nan=torch.inf)
     b = torch.nan_to_num(b, nan=torch.inf)


### PR DESCRIPTION
I'm not actually sure why it doesn't work, but I tried on both Python
3.9 and 3.10 and it caused the same problem in both.

But I think specifying it as an attribute results in the same effect
anyway, so we'll just do that.
