### PR TITLE
Remove `from __future__ import annotations`

### DIFF
--- a/conduit/data/datasets/vision/isic.py
+++ b/conduit/data/datasets/vision/isic.py
@@ -1,5 +1,4 @@
 """ISIC Dataset."""
-from __future__ import annotations
 from enum import auto
 from itertools import islice
 import os

--- a/conduit/data/structures.py
+++ b/conduit/data/structures.py
@@ -1,5 +1,4 @@
 """Data structures."""
-from __future__ import annotations
 from abc import abstractmethod
 from collections.abc import Sequence
 from dataclasses import asdict, dataclass, field, fields, is_dataclass

--- a/conduit/logging.py
+++ b/conduit/logging.py
@@ -1,4 +1,3 @@
-from __future__ import annotations
 import logging
 import sys
 from typing import Optional

--- a/conduit/progress.py
+++ b/conduit/progress.py
@@ -1,4 +1,3 @@
-from __future__ import annotations
 from enum import Enum
 from typing import Any, Callable, Dict, Optional, Union, cast
 from typing_extensions import TypeAlias, override

--- a/tests/fair/datamodules_test.py
+++ b/tests/fair/datamodules_test.py
@@ -1,5 +1,4 @@
 """Test DataModules."""
-from __future__ import annotations
 from functools import partial
 from pathlib import Path
 from typing import Any, Final, Type

--- a/tests/metrics_test.py
+++ b/tests/metrics_test.py
@@ -1,5 +1,4 @@
 """Test metrics."""
-from __future__ import annotations
 from typing import Final
 
 import numpy as np


### PR DESCRIPTION
Not needed anymore since we updated to Python 3.10, and anyway, the `from __future__ import annotations` mechanism is deprecated (to be replace by [PEP 649](https://peps.python.org/pep-0649/) in Python 3.13).