### PR TITLE
Add new methods for transforming tabular data

### DIFF
--- a/conduit/data/datasets/tabular/base.py
+++ b/conduit/data/datasets/tabular/base.py
@@ -7,12 +7,22 @@ from torch.functional import Tensor
 
 from conduit.data.datasets.base import CdtDataset, I, S, Y
 from conduit.data.structures import TargetData
-from conduit.transforms.tabular import TabularTransform
+from conduit.transforms.tabular import TabularNormalize
 
 __all__ = ["CdtTabularDataset"]
 
 
 class CdtTabularDataset(CdtDataset[I, Tensor, Y, S]):
+    """A dataset for tabular data.
+
+    :param x: The input features.
+    :param y: The target data.
+    :param s: The sensitive attribute data.
+    :param non_ohe_indexes: The indexes of the non-one-hot-encoded features. If None, all features
+        are assumed to be one-hot-encoded. Transformations will only be applied to the
+        non-one-hot-encoded features.
+    :param feature_groups: List of one-hot-encoded feature groups. Each group is encoded as a slice.
+    """
     x: Tensor
 
     def __init__(
@@ -21,37 +31,28 @@ class CdtTabularDataset(CdtDataset[I, Tensor, Y, S]):
         x: Union[Tensor, npt.NDArray[np.floating], npt.NDArray[np.integer]],
         y: Optional[TargetData] = None,
         s: Optional[TargetData] = None,
-        transform: Optional[TabularTransform] = None,
-        target_transform: Optional[TabularTransform] = None,
-        cont_indexes: Optional[List[int]] = None,
-        disc_indexes: Optional[List[int]] = None,
+        non_ohe_indexes: Optional[List[int]] = None,
         feature_groups: Optional[List[slice]] = None,
-        target_groups: Optional[List[slice]] = None,
     ) -> None:
         if isinstance(x, np.ndarray):
             x = torch.as_tensor(x, dtype=torch.float32)
         super().__init__(x=x, y=y, s=s)
-        self.transform = transform
-        self.target_transform = target_transform
 
-        if self.transform is not None:
-            self.x = self.transform(self.x)
-        if self.target_transform is not None and self.y is not None:
-            self.y = self.target_transform(self.y)
-
-        self.cont_indexes = cont_indexes
-        self.disc_indexes = disc_indexes
+        self.non_ohe_indexes = non_ohe_indexes
         self.feature_groups = feature_groups
-        self.target_groups = target_groups
 
     @property
-    def x_cont(self) -> Optional[Tensor]:
-        if self.cont_indexes is None:
+    def x_non_ohe(self) -> Optional[Tensor]:
+        if self.non_ohe_indexes is None:
             return None
-        return self.x[:, self.cont_indexes]
+        return self.x[:, self.non_ohe_indexes]
 
-    @property
-    def x_disc(self) -> Optional[Tensor]:
-        if self.disc_indexes is None:
-            return None
-        return self.x[:, self.disc_indexes]
+    def fit_transform_(self, transform: TabularNormalize) -> None:
+        """Fit a transformation to the non-one-hot-encoded features and transfrom in-place."""
+        if (x_non_ohe := self.x_non_ohe) is not None:
+            self.x[:, self.non_ohe_indexes] = transform.fit_transform(x_non_ohe)
+
+    def transform_(self, transform: TabularNormalize) -> None:
+        """Transform the non-one-hot-encoded features in-place."""
+        if (x_non_ohe := self.x_non_ohe) is not None:
+            self.x[:, self.non_ohe_indexes] = transform.transform(x_non_ohe)

--- a/conduit/data/datasets/tabular/base.py
+++ b/conduit/data/datasets/tabular/base.py
@@ -23,6 +23,7 @@ class CdtTabularDataset(CdtDataset[I, Tensor, Y, S]):
         non-one-hot-encoded features.
     :param feature_groups: List of one-hot-encoded feature groups. Each group is encoded as a slice.
     """
+
     x: Tensor
 
     def __init__(

--- a/conduit/data/datasets/tabular/base.py
+++ b/conduit/data/datasets/tabular/base.py
@@ -2,6 +2,7 @@ from typing import List, Optional, Union
 
 import numpy as np
 import numpy.typing as npt
+from ranzen import some
 import torch
 from torch.functional import Tensor
 
@@ -49,11 +50,11 @@ class CdtTabularDataset(CdtDataset[I, Tensor, Y, S]):
         return self.x[:, self.non_ohe_indexes]
 
     def fit_transform_(self, transform: TabularNormalize) -> None:
-        """Fit a transformation to the non-one-hot-encoded features and transfrom in-place."""
-        if (x_non_ohe := self.x_non_ohe) is not None:
+        """Fit a transformation to the non-one-hot-encoded features and transform in-place."""
+        if some(x_non_ohe := self.x_non_ohe):
             self.x[:, self.non_ohe_indexes] = transform.fit_transform(x_non_ohe)
 
     def transform_(self, transform: TabularNormalize) -> None:
         """Transform the non-one-hot-encoded features in-place."""
-        if (x_non_ohe := self.x_non_ohe) is not None:
+        if some(x_non_ohe := self.x_non_ohe):
             self.x[:, self.non_ohe_indexes] = transform.transform(x_non_ohe)

--- a/conduit/data/datasets/tabular/dummy.py
+++ b/conduit/data/datasets/tabular/dummy.py
@@ -32,7 +32,7 @@ class RandomTabularDataset(CdtTabularDataset):
             prev += ohe_feats.shape[1]
 
         feats = pd.concat(feats_dict.values(), axis=1)
-        num_disc_feats = feats.shape[1]
+        num_ohe_feats = feats.shape[1]
 
         for i in range(num_cont_features):
             cont_feat = rng.random(num_samples)
@@ -53,6 +53,5 @@ class RandomTabularDataset(CdtTabularDataset):
             y=y,
             s=s,
             feature_groups=feature_groups,
-            disc_indexes=list(range(num_disc_feats)),
-            cont_indexes=list(range(num_disc_feats, feats.shape[1])),
+            non_ohe_indexes=list(range(num_ohe_feats, feats.shape[1])),
         )


### PR DESCRIPTION
You can now do it like this:

```python
    tf = ZScoreNormalize()
    train.fit_transform_(tf)
    test.transform_(tf)
```
In the next step, I could add this code to `_get_splits()` in the tabular data module.

I also renamed `cont_features` to `non_ohe_features` because that's the thing we actually care about. And then I removed `disc_features` because the same information is contained in `feature_groups`.